### PR TITLE
feat(nvim): enhance LSP and window management keymaps for 2025

### DIFF
--- a/nvim/.config/nvim/after/plugin/lsp.lua
+++ b/nvim/.config/nvim/after/plugin/lsp.lua
@@ -8,21 +8,57 @@ vim.api.nvim_create_autocmd('LspAttach', {
 
     -- Buffer local mappings.
     -- See `:help vim.lsp.*` for documentation on any of the below functions
-    local opts = { buffer = ev.buf }
     local builtin = require('telescope.builtin')
 
-    vim.keymap.set('n', 'gd', vim.lsp.buf.definition, opts, { desc = "Go To Definition" })
-    vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, opts, { desc = "Go To Decleration" })
-    vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, opts, { desc = "Go To Implementation" })
-    vim.keymap.set('n', 'K', vim.lsp.buf.hover, opts, { desc = "View Signiture in hover" })
-    vim.keymap.set('n', 'gk>', vim.lsp.buf.signature_help, opts, { desc = "View signiture" })
-    vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, opts, { desc = "Refactor" })
-    vim.keymap.set('n', '<leader>ca', vim.lsp.buf.code_action, { desc = "Code Action" })
+    -- Core navigation (g prefix for "goto")
+    vim.keymap.set('n', 'gd', vim.lsp.buf.definition, { buffer = ev.buf, desc = "Go to definition" })
+    vim.keymap.set('n', 'gD', vim.lsp.buf.declaration, { buffer = ev.buf, desc = "Go to declaration" })
+    vim.keymap.set('n', 'gi', vim.lsp.buf.implementation, { buffer = ev.buf, desc = "Go to implementation" })
+    vim.keymap.set('n', 'gt', vim.lsp.buf.type_definition, { buffer = ev.buf, desc = "Go to type definition" })
     vim.keymap.set("n", "gr", builtin.lsp_references, {
+      buffer = ev.buf,
       noremap = true,
       silent = true,
-      desc = "Telescope: Search all references"
+      desc = "Go to references"
     })
+
+    -- Hover and documentation
+    vim.keymap.set('n', 'K', vim.lsp.buf.hover, { buffer = ev.buf, desc = "Hover documentation" })
+    vim.keymap.set('n', '<C-k>', vim.lsp.buf.signature_help, { buffer = ev.buf, desc = "Signature help" })
+    vim.keymap.set('i', '<C-k>', vim.lsp.buf.signature_help, { buffer = ev.buf, desc = "Signature help" })
+
+    -- Code actions and refactoring
+    vim.keymap.set('n', '<leader>ca', vim.lsp.buf.code_action, { buffer = ev.buf, desc = "Code action" })
+    vim.keymap.set('v', '<leader>ca', vim.lsp.buf.code_action, { buffer = ev.buf, desc = "Code action (range)" })
+    vim.keymap.set('n', '<leader>rn', vim.lsp.buf.rename, { buffer = ev.buf, desc = "Rename symbol" })
+
+    -- LSP workspace (leader + lw prefix)
+    vim.keymap.set('n', '<leader>lwa', vim.lsp.buf.add_workspace_folder, { buffer = ev.buf, desc = "Add workspace folder" })
+    vim.keymap.set('n', '<leader>lwr', vim.lsp.buf.remove_workspace_folder, { buffer = ev.buf, desc = "Remove workspace folder" })
+    vim.keymap.set('n', '<leader>lwl', function()
+      print(vim.inspect(vim.lsp.buf.list_workspace_folders()))
+    end, { buffer = ev.buf, desc = "List workspace folders" })
+
+    -- LSP info and symbols (leader + l prefix)
+    -- Note: <leader>li is defined globally in remap.lua so it's always available
+    vim.keymap.set('n', '<leader>lr', '<cmd>LspRestart<CR>', { buffer = ev.buf, desc = "Restart LSP" })
+    vim.keymap.set('n', '<leader>ls', builtin.lsp_document_symbols, { buffer = ev.buf, desc = "Document symbols" })
+    vim.keymap.set('n', '<leader>lS', builtin.lsp_dynamic_workspace_symbols, { buffer = ev.buf, desc = "Workspace symbols" })
+
+    -- Formatting
+    vim.keymap.set('n', '<leader>lf', function()
+      vim.lsp.buf.format({ async = true })
+    end, { buffer = ev.buf, desc = "Format buffer" })
+    vim.keymap.set('v', '<leader>lf', function()
+      vim.lsp.buf.format({ async = true })
+    end, { buffer = ev.buf, desc = "Format selection" })
+
+    -- Inlay hints (Neovim 0.10+)
+    if vim.lsp.inlay_hint then
+      vim.keymap.set('n', '<leader>lh', function()
+        vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled())
+      end, { buffer = ev.buf, desc = "Toggle inlay hints" })
+    end
   end,
 })
 

--- a/nvim/.config/nvim/lua/config/remap.lua
+++ b/nvim/.config/nvim/lua/config/remap.lua
@@ -63,3 +63,36 @@ vim.keymap.set('n', '<leader>c', function() require 'mdeval'.eval_code_block() e
 
 -- Zen Mode
 vim.keymap.set("n", "<leader>z", "<cmd>ZenMode<CR>", { desc = "Toggle Zen Mode" })
+
+-- LSP (global - always available)
+vim.keymap.set("n", "<leader>li", "<cmd>LspInfo<CR>", { desc = "LSP info" })
+
+-- Window Management
+-- Split windows
+vim.keymap.set("n", "<leader>wv", "<C-w>v", { desc = "Split window vertically" })
+vim.keymap.set("n", "<leader>wh", "<C-w>s", { desc = "Split window horizontally" })
+vim.keymap.set("n", "<leader>we", "<C-w>=", { desc = "Make splits equal size" })
+vim.keymap.set("n", "<leader>wx", "<cmd>close<CR>", { desc = "Close current split" })
+vim.keymap.set("n", "<leader>wo", "<C-w>o", { desc = "Close other splits (only this)" })
+
+-- Navigate between splits (supplementary to smart-splits plugin)
+vim.keymap.set("n", "<leader>wj", "<C-w>j", { desc = "Move to split below" })
+vim.keymap.set("n", "<leader>wk", "<C-w>k", { desc = "Move to split above" })
+vim.keymap.set("n", "<leader>wl", "<C-w>l", { desc = "Move to split right" })
+vim.keymap.set("n", "<leader>ww", "<C-w>w", { desc = "Switch between splits" })
+
+-- Rotate windows
+vim.keymap.set("n", "<leader>wr", "<C-w>r", { desc = "Rotate splits downward/right" })
+vim.keymap.set("n", "<leader>wR", "<C-w>R", { desc = "Rotate splits upward/left" })
+
+-- Move splits
+vim.keymap.set("n", "<leader>wH", "<C-w>H", { desc = "Move split to far left" })
+vim.keymap.set("n", "<leader>wJ", "<C-w>J", { desc = "Move split to bottom" })
+vim.keymap.set("n", "<leader>wK", "<C-w>K", { desc = "Move split to top" })
+vim.keymap.set("n", "<leader>wL", "<C-w>L", { desc = "Move split to far right" })
+
+-- Resize splits
+vim.keymap.set("n", "<leader>w<", "<C-w>5<", { desc = "Decrease width" })
+vim.keymap.set("n", "<leader>w>", "<C-w>5>", { desc = "Increase width" })
+vim.keymap.set("n", "<leader>w-", "<C-w>5-", { desc = "Decrease height" })
+vim.keymap.set("n", "<leader>w+", "<C-w>5+", { desc = "Increase height" })

--- a/nvim/.config/nvim/lua/plugins/which_key.lua
+++ b/nvim/.config/nvim/lua/plugins/which_key.lua
@@ -30,9 +30,22 @@ return {
       -- Git subgroups
       { "<leader>gh", group = "GitHub" },
 
-      -- LSP subgroups
+      -- LSP subgroups and commands
       { "<leader>la", group = "Actions" },
       { "<leader>lw", group = "Workspace" },
+      { "<leader>lwa", desc = "Add workspace folder" },
+      { "<leader>lwr", desc = "Remove workspace folder" },
+      { "<leader>lwl", desc = "List workspace folders" },
+      { "<leader>li", desc = "LSP info" },
+      { "<leader>lr", desc = "Restart LSP" },
+      { "<leader>ls", desc = "Document symbols" },
+      { "<leader>lS", desc = "Workspace symbols" },
+      { "<leader>lf", desc = "Format buffer/selection" },
+      { "<leader>lh", desc = "Toggle inlay hints" },
+
+      -- Code actions (dynamically mapped when LSP attaches)
+      { "<leader>rn", desc = "Rename symbol" },
+      { "<leader>ca", desc = "Code action" },
 
       -- Notes (Obsidian) subgroups
       { "<leader>nd", group = "Daily" },
@@ -50,8 +63,25 @@ return {
       { "<leader>ut", group = "Toggle" },
 
       -- Window management
-      { "<leader>wh", group = "Horizontal Split" },
-      { "<leader>wv", group = "Vertical Split" },
+      { "<leader>wv", desc = "Split window vertically" },
+      { "<leader>wh", desc = "Split window horizontally" },
+      { "<leader>we", desc = "Make splits equal size" },
+      { "<leader>wx", desc = "Close current split" },
+      { "<leader>wo", desc = "Close other splits" },
+      { "<leader>ww", desc = "Switch between splits" },
+      { "<leader>wj", desc = "Move to split below" },
+      { "<leader>wk", desc = "Move to split above" },
+      { "<leader>wl", desc = "Move to split right" },
+      { "<leader>wr", desc = "Rotate splits downward/right" },
+      { "<leader>wR", desc = "Rotate splits upward/left" },
+      { "<leader>wH", desc = "Move split to far left" },
+      { "<leader>wJ", desc = "Move split to bottom" },
+      { "<leader>wK", desc = "Move split to top" },
+      { "<leader>wL", desc = "Move split to far right" },
+      { "<leader>w<", desc = "Decrease width" },
+      { "<leader>w>", desc = "Increase width" },
+      { "<leader>w-", desc = "Decrease height" },
+      { "<leader>w+", desc = "Increase height" },
 
       -- Bracket mappings
       { "]", group = "Next" },
@@ -59,8 +89,15 @@ return {
       { "]d", desc = "Next diagnostic" },
       { "[d", desc = "Previous diagnostic" },
 
-      -- Goto mappings
+      -- Goto mappings (LSP)
       { "g", group = "Goto" },
+      { "gd", desc = "Go to definition" },
+      { "gD", desc = "Go to declaration" },
+      { "gi", desc = "Go to implementation" },
+      { "gt", desc = "Go to type definition" },
+      { "gr", desc = "Go to references" },
+      { "K", desc = "Hover documentation" },
+      { "<C-k>", desc = "Signature help" },
       { "gz", group = "Surround" },
 
       -- Mode-specific groups


### PR DESCRIPTION
LSP Improvements:
- Add comprehensive LSP keymaps following 2025 best practices
- Add gt for type definition navigation
- Add <C-k> signature help (normal + insert mode)
- Add workspace folder management (lwa, lwr, lwl)
- Add document/workspace symbols via Telescope (ls, lS)
- Add LSP restart command (lr)
- Add async formatting for buffer/selection (lf)
- Add inlay hints toggle for Neovim 0.10+ (lh)
- Add visual mode code actions
- Fix: Add global <leader>li mapping so LSP group shows in which-key

Window Management:
- Add complete window management keymaps under <leader>w
- Split: wv (vertical), wh (horizontal), we (equal size)
- Close: wx (current), wo (others only)
- Navigate: wj/wk/wl (directional), ww (cycle)
- Rotate: wr (down/right), wR (up/left)
- Move: wH/wJ/wK/wL (to edges)
- Resize: w</w> (width), w-/w+ (height)

Which-Key Updates:
- Add descriptions for all new LSP commands
- Add descriptions for all window management commands
- Add goto command descriptions (gd, gD, gi, gt, gr, K)
- Improve consistency in description formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)