### PR TITLE
feat(nvim): add Java development support with JDTLS

### DIFF
--- a/nvim/.config/nvim/after/plugin/java.lua
+++ b/nvim/.config/nvim/after/plugin/java.lua
@@ -1,0 +1,24 @@
+-- Java-specific keymaps (only active when JDTLS is attached)
+vim.api.nvim_create_autocmd("FileType", {
+  pattern = "java",
+  callback = function()
+    local jdtls = require('jdtls')
+    local opts = { buffer = true }
+
+    -- Code actions
+    vim.keymap.set('n', '<leader>jo', jdtls.organize_imports, { buffer = true, desc = "Organize imports" })
+    vim.keymap.set('n', '<leader>jv', jdtls.extract_variable, { buffer = true, desc = "Extract variable" })
+    vim.keymap.set('v', '<leader>jv', function() jdtls.extract_variable(true) end, { buffer = true, desc = "Extract variable" })
+    vim.keymap.set('n', '<leader>jc', jdtls.extract_constant, { buffer = true, desc = "Extract constant" })
+    vim.keymap.set('v', '<leader>jc', function() jdtls.extract_constant(true) end, { buffer = true, desc = "Extract constant" })
+    vim.keymap.set('v', '<leader>jm', function() jdtls.extract_method(true) end, { buffer = true, desc = "Extract method" })
+
+    -- Test actions
+    vim.keymap.set('n', '<leader>jtc', jdtls.test_class, { buffer = true, desc = "Test class" })
+    vim.keymap.set('n', '<leader>jtn', jdtls.test_nearest_method, { buffer = true, desc = "Test nearest method" })
+
+    -- DAP (debugging) keymaps
+    vim.keymap.set('n', '<leader>jdc', function() require('jdtls').test_class({ config = { console = 'integratedTerminal' }}) end, { buffer = true, desc = "Debug class" })
+    vim.keymap.set('n', '<leader>jdn', function() require('jdtls').test_nearest_method({ config = { console = 'integratedTerminal' }}) end, { buffer = true, desc = "Debug nearest method" })
+  end
+})

--- a/nvim/.config/nvim/ftplugin/java.lua
+++ b/nvim/.config/nvim/ftplugin/java.lua
@@ -1,0 +1,116 @@
+-- Java-specific settings
+vim.opt_local.shiftwidth = 4
+vim.opt_local.tabstop = 4
+vim.opt_local.cmdheight = 2
+
+local jdtls = require('jdtls')
+
+-- Find project root
+local project_name = vim.fn.fnamemodify(vim.fn.getcwd(), ':p:h:t')
+local workspace_dir = vim.fn.stdpath('data') .. '/jdtls-workspaces/' .. project_name
+
+-- Get Mason paths for Java bundles
+local mason_path = vim.fn.stdpath('data') .. '/mason/packages'
+local bundles = {}
+
+-- Add java-debug-adapter bundle
+local java_debug_path = mason_path .. '/java-debug-adapter/extension/server/com.microsoft.java.debug.plugin-*.jar'
+local java_debug_bundle = vim.fn.glob(java_debug_path, true)
+if java_debug_bundle ~= '' then
+  table.insert(bundles, java_debug_bundle)
+end
+
+-- Add java-test bundle
+local java_test_path = mason_path .. '/java-test/extension/server/com.microsoft.java.test.plugin-*.jar'
+local java_test_bundle = vim.fn.glob(java_test_path, true)
+if java_test_bundle ~= '' then
+  table.insert(bundles, java_test_bundle)
+end
+
+local config = {
+  cmd = {
+    'jdtls',
+    '-data', workspace_dir
+  },
+  root_dir = vim.fs.dirname(vim.fs.find({'gradlew', '.git', 'mvnw', 'build.gradle'}, { upward = true })[1]),
+  settings = {
+    java = {
+      eclipse = {
+        downloadSources = true,
+      },
+      configuration = {
+        updateBuildConfiguration = "interactive",
+        runtimes = {
+          {
+            name = "JavaSE-21",
+            path = vim.fn.getenv("JAVA_HOME"),
+          }
+        }
+      },
+      maven = {
+        downloadSources = true,
+      },
+      implementationsCodeLens = {
+        enabled = true,
+      },
+      referencesCodeLens = {
+        enabled = true,
+      },
+      references = {
+        includeDecompiledSources = true,
+      },
+      format = {
+        enabled = true,
+        settings = {
+          url = vim.fn.stdpath("config") .. "/lang-servers/intellij-java-google-style.xml",
+          profile = "GoogleStyle",
+        },
+      },
+    },
+    signatureHelp = { enabled = true },
+    completion = {
+      favoriteStaticMembers = {
+        "org.hamcrest.MatcherAssert.assertThat",
+        "org.hamcrest.Matchers.*",
+        "org.hamcrest.CoreMatchers.*",
+        "org.junit.jupiter.api.Assertions.*",
+        "java.util.Objects.requireNonNull",
+        "java.util.Objects.requireNonNullElse",
+        "org.mockito.Mockito.*"
+      },
+      importOrder = {
+        "java",
+        "javax",
+        "com",
+        "org"
+      },
+    },
+    extendedClientCapabilities = jdtls.extendedClientCapabilities,
+    sources = {
+      organizeImports = {
+        starThreshold = 9999,
+        staticStarThreshold = 9999,
+      },
+    },
+    codeGeneration = {
+      toString = {
+        template = "${object.className}{${member.name()}=${member.value}, ${otherMembers}}"
+      },
+      useBlocks = true,
+    },
+  },
+  init_options = {
+    bundles = bundles
+  },
+  capabilities = require('cmp_nvim_lsp').default_capabilities(),
+  on_attach = function(client, bufnr)
+    -- Enable completion triggered by <c-x><c-o>
+    vim.api.nvim_buf_set_option(bufnr, 'omnifunc', 'v:lua.vim.lsp.omnifunc')
+
+    -- Setup DAP
+    jdtls.setup_dap({ hotcodereplace = 'auto' })
+    require('jdtls.dap').setup_dap_main_class_configs()
+  end,
+}
+
+jdtls.start_or_attach(config)

--- a/nvim/.config/nvim/lua/plugins/java.lua
+++ b/nvim/.config/nvim/lua/plugins/java.lua
@@ -1,0 +1,7 @@
+return {
+  "mfussenegger/nvim-jdtls",
+  ft = "java",
+  dependencies = {
+    "mfussenegger/nvim-dap",
+  },
+}

--- a/nvim/.config/nvim/lua/plugins/which_key.lua
+++ b/nvim/.config/nvim/lua/plugins/which_key.lua
@@ -15,6 +15,7 @@ return {
       { "<leader>f", group = "Find/Format" },
       { "<leader>g", group = "Git" },
       { "<leader>h", group = "Harpoon" },
+      { "<leader>j", group = "Java" },
       { "<leader>l", group = "LSP" },
       { "<leader>m", group = "Marks" },
       { "<leader>n", group = "Notes" },
@@ -29,6 +30,18 @@ return {
 
       -- Git subgroups
       { "<leader>gh", group = "GitHub" },
+
+      -- Java subgroups and commands
+      { "<leader>jo", desc = "Organize imports" },
+      { "<leader>jv", desc = "Extract variable" },
+      { "<leader>jc", desc = "Extract constant" },
+      { "<leader>jm", desc = "Extract method" },
+      { "<leader>jt", group = "Test" },
+      { "<leader>jtc", desc = "Test class" },
+      { "<leader>jtn", desc = "Test nearest method" },
+      { "<leader>jd", group = "Debug" },
+      { "<leader>jdc", desc = "Debug class" },
+      { "<leader>jdn", desc = "Debug nearest method" },
 
       -- LSP subgroups and commands
       { "<leader>la", group = "Actions" },


### PR DESCRIPTION
Add comprehensive Java development setup:
- nvim-jdtls plugin for Java LSP
- ftplugin/java.lua for per-project JDTLS configuration
- Support for debugging and test runner
- Java-specific keymaps under <leader>j
- Gradle build tool integration
- Java Corretto 21 runtime configuration

Features:
- Organize imports (<leader>jo)
- Extract variable/constant/method (<leader>jv/jc/jm)
- Run/debug tests (<leader>jt/jd)
- Full DAP integration with nvim-dap
- Code actions and refactoring
- Auto-download sources

🤖 Generated with [Claude Code](https://claude.com/claude-code)